### PR TITLE
[FIX] Deprecated warnings #23

### DIFF
--- a/src/Aliases.php
+++ b/src/Aliases.php
@@ -97,7 +97,7 @@ class Aliases implements \ArrayAccess
     /**
      * @inheritDoc
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): Alias
     {
         if (!isset($this->aliases[$offset])) {
             $this->aliases[$offset] = new Alias($offset, $this->apiCall);

--- a/src/Overrides.php
+++ b/src/Overrides.php
@@ -92,7 +92,7 @@ class Overrides implements \ArrayAccess
     /**
      * @inheritDoc
      */
-    public function offsetGet($overrideId)
+    public function offsetGet($overrideId): Override
     {
         if (!isset($this->overrides[$overrideId])) {
             $this->overrides[$overrideId] = new Override($this->collectionName, $overrideId, $this->apiCall);

--- a/src/Synonyms.php
+++ b/src/Synonyms.php
@@ -90,7 +90,7 @@ class Synonyms implements \ArrayAccess
     /**
      * @inheritDoc
      */
-    public function offsetGet($synonymId)
+    public function offsetGet($synonymId): Synonym
     {
         if (!isset($this->synonyms[$synonymId])) {
             $this->synonyms[$synonymId] = new Synonym($this->collectionName, $synonymId, $this->apiCall);


### PR DESCRIPTION
## Change Summary
Fix return types of `offsetGet` for `Aliases`, `Overrides` and `Synonyms` classes.

## PR Checklist
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
