### PR TITLE
Ignore uneeded files for distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/examples       export-ignore
+.gitattributes  export-ignore
+.gitignore      export-ignore
+phpcs.xml       export-ignore


### PR DESCRIPTION
## Change Summary

A good idea is to exclude unneeded dev files from the final production zip archive file, which is also downloaded by composer (unless `--prefer -source` flag is specified).

Those files are actually only useful when working on the library itself.


In case you are not familiar, further information about `export-ignore` can be found below for instance:
* http://www.pixelite.co.nz/article/using-git-attributes-exclude-files-your-release/
* https://madewithlove.be/gitattributes/

I hope it helps @kishorenc / @AbdullahFaqeir 😊


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
