### PR TITLE
retrieve preset by name, implement array access for presets, analyticsRules

### DIFF
--- a/src/AnalyticsRules.php
+++ b/src/AnalyticsRules.php
@@ -2,7 +2,7 @@
 
 namespace Typesense;
 
-class AnalyticsRules
+class AnalyticsRules implements \ArrayAccess
 {
     const RESOURCE_PATH = '/analytics/rules';
 
@@ -35,5 +35,41 @@ class AnalyticsRules
     private function endpoint_path($operation = null)
     {
         return self::RESOURCE_PATH . ($operation === null ? '' : "/$operation");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->analyticsRules[$offset]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetGet($offset): AnalyticsRule
+    {
+        if (!isset($this->analyticsRules[$offset])) {
+            $this->analyticsRules[$offset] = new AnalyticsRule($offset, $this->apiCall);
+        }
+
+        return $this->analyticsRules[$offset];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetSet($offset, $value): void
+    {
+        $this->analyticsRules[$offset] = $value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetUnset($offset): void
+    {
+        unset($this->analyticsRules[$offset]);
     }
 }

--- a/src/Preset.php
+++ b/src/Preset.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Typesense;
+
+use Http\Client\Exception as HttpClientException;
+use Typesense\Exceptions\TypesenseClientError;
+
+/**
+ * Class Preset
+ *
+ * @package \Typesense
+ */
+class Preset
+{
+    /**
+     * @var string
+     */
+    private string $presetName;
+
+    /**
+     * @var ApiCall
+     */
+    private ApiCall $apiCall;
+
+    /**
+     * Preset constructor.
+     *
+     * @param string  $presetName
+     * @param ApiCall $apiCall
+     */
+    public function __construct(string $presetName, ApiCall $apiCall)
+    {
+        $this->presetName = $presetName;
+        $this->apiCall = $apiCall;
+    }
+
+    /**
+     * @return array
+     * @throws TypesenseClientError|HttpClientException
+     */
+    public function retrieve(): array
+    {
+        return $this->apiCall->get($this->endPointPath(), []);
+    }
+
+    /**
+     * @return array
+     * @throws TypesenseClientError|HttpClientException
+     */
+    public function delete(): array
+    {
+        return $this->apiCall->delete($this->endPointPath());
+    }
+
+    /**
+     * @return string
+     */
+    public function endPointPath(): string
+    {
+        return sprintf('%s/%s', Presets::PRESETS_PATH, $this->presetName);
+    }
+}

--- a/tests/Feature/AnalyticsRulesTest.php
+++ b/tests/Feature/AnalyticsRulesTest.php
@@ -44,17 +44,17 @@ class AnalyticsRulesTest extends TestCase
 
     public function testCanRetrieveARule(): void
     {
-        $returnData = $this->client()->analytics->rules()->{$this->ruleName}->retrieve();
+        $returnData = $this->client()->analytics->rules()[$this->ruleName]->retrieve();
         $this->assertEquals($returnData['name'], $this->ruleName);
     }
 
     public function testCanDeleteARule(): void
     {
-        $returnData = $this->client()->analytics->rules()->{$this->ruleName}->delete();
+        $returnData = $this->client()->analytics->rules()[$this->ruleName]->delete();
         $this->assertEquals($returnData['name'], $this->ruleName);
 
         $this->expectException(ObjectNotFound::class);
-        $this->client()->analytics->rules()->{$this->ruleName}->retrieve();
+        $this->client()->analytics->rules()[$this->ruleName]->retrieve();
     }
 
     public function testCanRetrieveAllRules(): void


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
```php
// Changes from
$client->presets->get();
$client->presets->delete('presetName');
$client->presets->put([
            'preset_name' => 'name',
            'preset_data' =>  [
                'value' => [
                    'query_by' => "*",
                ],
            ];
// To
$client->presets->retrieve();
$client->presets['presetName']->delete();
$client->presets->upsert('presetName', [
            'value' => [
                'query_by' => "*",
            ],
        ]);
```
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
