### PR TITLE
Updated multiSearch perform type in doctype to match actual type

### DIFF
--- a/src/MultiSearch.php
+++ b/src/MultiSearch.php
@@ -30,7 +30,7 @@ class MultiSearch
     }
 
     /**
-     * @param string $searches
+     * @param array $searches
      * @param array $queryParameters
      *
      * @return array


### PR DESCRIPTION
## Change Summary
When using the multisearch I put a string in the first argument instead of an array as that's what my IDE was saying it required.

I got an error saying it required an array.

Caused by a type mismatch in the docblock and the actual php type in the function parameters.

Very small change :)

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
