### PR TITLE
fix(documents): add parameters to document deletion method

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -79,11 +79,12 @@ class Document
     }
 
     /**
+     * @param array $options
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
-    public function delete(): array
+    public function delete(array $options = []): array
     {
-        return $this->apiCall->delete($this->endpointPath());
+        return $this->apiCall->delete($this->endpointPath(), true, $options);
     }
 }


### PR DESCRIPTION
### TLDR
Closes #83 

## Change Summary
<!--- Described your changes here -->
This pull request includes a modification to the `delete` method in the `src/Document.php` file to accept an optional `$options` parameter. This change ensures that additional options can be passed when deleting a document.

Changes to `delete` method:

* [`src/Document.php`](diffhunk://#diff-be827c95802130abd75c2695f6a163761f3d8aa2490eb1445a8879755c14390fR82-R88): Modified the `delete` method to accept an optional `$options` parameter and updated the method call to include this parameter.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
