### PR TITLE
Fix HTTP Client Type Handling in API Calls

### DIFF
--- a/src/Lib/Configuration.php
+++ b/src/Lib/Configuration.php
@@ -223,9 +223,9 @@ class Configuration
     }
 
     /**
-     * @return ClientInterface
+     * @return ClientInterface | HttpMethodsClient
      */
-    public function getClient(): ClientInterface
+    public function getClient(): ClientInterface | HttpMethodsClient
     {
         if ($this->client === null) {
             $discoveredClient = Psr18ClientDiscovery::find();


### PR DESCRIPTION
### TLDR
Support both PSR-18 ClientInterface and HttpMethodsClient implementations in API calls.

## Change Summary
### What is this?
This change addresses a critical compatibility issue where the Typesense PHP client was not properly handling different HTTP client implementations. Users were encountering errors when trying to use standard PSR-18 compatible clients, limiting the library's flexibility and causing unexpected failures. This fix enables broader compatibility with different HTTP client implementations while maintaining existing functionality.

### Changes
#### Code Improvements:
1. **In `src/ApiCall.php`**:
   - Updated `$client` property to support both `ClientInterface` and `HttpMethodsClient` types
   - Added conditional request handling logic to support both client types
   - Implemented PSR-17 factory discovery for request and stream creation
   - Added proper request building for `ClientInterface` implementations

2. **In `src/Lib/Configuration.php`**:
   - Updated return type declaration in `getClient()` method to support both client types
   - Fixed type documentation to reflect dual client type support

#### Technical Details:
- Added support for creating requests using PSR-17 factories when using `ClientInterface`
- Maintained backward compatibility with `HttpMethodsClient` implementation
- Properly handled request components (headers, body, query parameters) for both client types
- Improved type declarations to reflect the dual client support

### Context
This change addresses two reported issues:

1. Issue #82: Users experiencing errors after upgrading to version 5.0.0
2. Issue #77: TypeError when passing PSR-18 ClientInterface instances:
   ```
   TypeError: Http\Client\Common\HttpMethodsClient::__construct(): 
   Argument #1 ($httpClient) must be of type Http\Client\HttpClient, 
   Http\Discovery\Psr18Client given
   ```

The fix ensures that users can now use any PSR-18 compatible client implementation without encountering type errors, while maintaining support for the existing `HttpMethodsClient` functionality. This improvement makes the library more flexible and robust, following PHP-FIG standards for HTTP client implementations.


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
