### PR TITLE
Fix scoped key generation without parameters

### DIFF
--- a/src/Keys.php
+++ b/src/Keys.php
@@ -58,7 +58,7 @@ class Keys implements \ArrayAccess
         string $searchKey,
         array $parameters
     ): string {
-        $paramStr     = json_encode($parameters, JSON_THROW_ON_ERROR);
+        $paramStr     = json_encode((object)$parameters, JSON_THROW_ON_ERROR);
         $digest       = base64_encode(
             hash_hmac(
                 'sha256',

--- a/tests/Feature/KeysTest.php
+++ b/tests/Feature/KeysTest.php
@@ -73,4 +73,13 @@ class KeysTest extends TestCase
         ]);
         $this->assertEquals($scopedSearchKey, $result);
     }
+
+    public function testGenerateScopedSearchKeyWithoutParams(): void
+    {
+        $searchKey = "RN23GFr1s6jQ9kgSNg2O7fYcAUXU7127";
+        $scopedSearchKey =
+            "R2pFZkxSemhGZmEvOXd2WWpYNWVSTzF2N2xRSk9jQmlpZ2NpdnloUTFGYz1STjIze30=";
+        $result = $this->client()->keys->generateScopedSearchKey($searchKey, []);
+        $this->assertEquals($scopedSearchKey, $result);
+    }
 }


### PR DESCRIPTION
## Change Summary

In case generateScopedSearchKey() is called with an empty parameters array the json encoding would result in '[]' which results in a broken scoped key and an unhelpful 401 permission error from typesense.

Cast input to an object, so we end up with '{}' for that case.

## PR Checklist

- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
