### PR TITLE
fix: don't throw while retrying

### DIFF
--- a/src/ApiCall.php
+++ b/src/ApiCall.php
@@ -273,12 +273,12 @@ class ApiCall
                     continue;
                 }
                 $this->setNodeHealthCheck($node, false);
-                throw $this->getException($exception->getResponse()
+                $lastException = $this->getException($exception->getResponse()
                     ->getStatusCode())
                     ->setMessage($exception->getMessage());
             } catch (TypesenseClientError | HttpClientException $exception) {
                 $this->setNodeHealthCheck($node, false);
-                throw $exception;
+                $lastException = $exception;
             } catch (Exception $exception) {
                 $this->setNodeHealthCheck($node, false);
                 $lastException = $exception;


### PR DESCRIPTION
## Change Summary
When using multiple nodes if one of the nodes is not reachable we currently throw an error without retrying.

This PR will save the last error and throw once all retries are exhausted.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
