### PR TITLE
fix(config): remove type annotation on `getClient` for backwards compat

### DIFF
--- a/src/Lib/Configuration.php
+++ b/src/Lib/Configuration.php
@@ -235,7 +235,7 @@ class Configuration
     /**
      * @return ClientInterface | HttpMethodsClient
      */
-    public function getClient(): ClientInterface | HttpMethodsClient
+    public function getClient()
     {
         if ($this->client === null) {
             $discoveredClient = Psr18ClientDiscovery::find();


### PR DESCRIPTION
## Change Summary
- fix #92 
- keep phpdoc in place for type hints

<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
