### PR TITLE
feat: add support for v30 synonym sets

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -91,6 +91,11 @@ class Client
     public NLSearchModels $nlSearchModels;
 
     /**
+     * @var SynonymSets
+     */
+    public SynonymSets $synonymSets;
+
+    /**
      * @var ApiCall
      */
     private ApiCall $apiCall;
@@ -121,6 +126,7 @@ class Client
         $this->stemming     = new Stemming($this->apiCall);
         $this->conversations = new Conversations($this->apiCall);
         $this->nlSearchModels = new NLSearchModels($this->apiCall);
+        $this->synonymSets = new SynonymSets($this->apiCall);
     }
 
     /**
@@ -233,5 +239,13 @@ class Client
     public function getNLSearchModels(): NLSearchModels
     {
         return $this->nlSearchModels;
+    }
+
+    /**
+     * @return SynonymSets
+     */
+    public function getSynonymSets(): SynonymSets
+    {
+        return $this->synonymSets;
     }
 }

--- a/src/SynonymSet.php
+++ b/src/SynonymSet.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Typesense;
+
+use Http\Client\Exception as HttpClientException;
+use Typesense\Exceptions\TypesenseClientError;
+
+/**
+ * Class SynonymSet
+ *
+ * @package \Typesense
+ */
+class SynonymSet
+{
+    /**
+     * @var string
+     */
+    private string $synonymSetName;
+
+    /**
+     * @var ApiCall
+     */
+    private ApiCall $apiCall;
+
+    /**
+     * SynonymSet constructor.
+     *
+     * @param string $synonymSetName
+     * @param ApiCall $apiCall
+     */
+    public function __construct(string $synonymSetName, ApiCall $apiCall)
+    {
+        $this->synonymSetName = $synonymSetName;
+        $this->apiCall        = $apiCall;
+    }
+
+    /**
+     * @return string
+     */
+    private function endPointPath(): string
+    {
+        return sprintf(
+            '%s/%s',
+            SynonymSets::RESOURCE_PATH,
+            encodeURIComponent($this->synonymSetName)
+        );
+    }
+
+    /**
+     * @param array $params
+     *
+     * @return array
+     * @throws TypesenseClientError|HttpClientException
+     */
+    public function upsert(array $params): array
+    {
+        return $this->apiCall->put($this->endPointPath(), $params);
+    }
+
+    /**
+     * @return array
+     * @throws TypesenseClientError|HttpClientException
+     */
+    public function retrieve(): array
+    {
+        return $this->apiCall->get($this->endPointPath(), []);
+    }
+
+    /**
+     * @return array
+     * @throws TypesenseClientError|HttpClientException
+     */
+    public function delete(): array
+    {
+        return $this->apiCall->delete($this->endPointPath());
+    }
+} 

--- a/src/SynonymSets.php
+++ b/src/SynonymSets.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Typesense;
+
+use Http\Client\Exception as HttpClientException;
+use Typesense\Exceptions\TypesenseClientError;
+
+/**
+ * Class SynonymSets
+ *
+ * @package \Typesense
+ */
+class SynonymSets implements \ArrayAccess
+{
+    public const RESOURCE_PATH = '/synonym_sets';
+
+    /**
+     * @var ApiCall
+     */
+    private ApiCall $apiCall;
+
+    /**
+     * @var array
+     */
+    private array $synonymSets = [];
+
+    /**
+     * SynonymSets constructor.
+     *
+     * @param ApiCall $apiCall
+     */
+    public function __construct(ApiCall $apiCall)
+    {
+        $this->apiCall = $apiCall;
+    }
+
+    /**
+     * @param string $synonymSetName
+     * @param array $config
+     *
+     * @return array
+     * @throws TypesenseClientError|HttpClientException
+     */
+    public function upsert(string $synonymSetName, array $config): array
+    {
+        return $this->apiCall->put(sprintf('%s/%s', static::RESOURCE_PATH, encodeURIComponent($synonymSetName)), $config);
+    }
+
+    /**
+     * @return array
+     * @throws TypesenseClientError|HttpClientException
+     */
+    public function retrieve(): array
+    {
+        return $this->apiCall->get(static::RESOURCE_PATH, []);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetExists($synonymSetName): bool
+    {
+        return isset($this->synonymSets[$synonymSetName]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetGet($synonymSetName): SynonymSet
+    {
+        if (!isset($this->synonymSets[$synonymSetName])) {
+            $this->synonymSets[$synonymSetName] = new SynonymSet($synonymSetName, $this->apiCall);
+        }
+
+        return $this->synonymSets[$synonymSetName];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetSet($synonymSetName, $value): void
+    {
+        $this->synonymSets[$synonymSetName] = $value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetUnset($synonymSetName): void
+    {
+        unset($this->synonymSets[$synonymSetName]);
+    }
+} 

--- a/tests/Feature/AnalyticsEventsTest.php
+++ b/tests/Feature/AnalyticsEventsTest.php
@@ -3,6 +3,7 @@
 namespace Feature;
 
 use Tests\TestCase;
+use Exception;
 
 class AnalyticsEventsTest extends TestCase
 {
@@ -11,6 +12,11 @@ class AnalyticsEventsTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+        
+        if ($this->isV30OrAbove()) {
+            $this->markTestSkipped('Analytics is deprecated in Typesense v30+');
+        }
+        
         $this->client()->collections->create([
             "name" => "products",
             "fields" => [
@@ -52,7 +58,13 @@ class AnalyticsEventsTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
-        $this->client()->analytics->rules()->{'product_queries_aggregation'}->delete();
+        
+        if (!$this->isV30OrAbove()) {
+            try {
+                $this->client()->analytics->rules()->{'product_queries_aggregation'}->delete();
+            } catch (Exception $e) {
+            }
+        }
     }
 
     public function testCanCreateAnEvent(): void

--- a/tests/Feature/AnalyticsRulesTest.php
+++ b/tests/Feature/AnalyticsRulesTest.php
@@ -4,6 +4,7 @@ namespace Feature;
 
 use Tests\TestCase;
 use Typesense\Exceptions\ObjectNotFound;
+use Exception;
 
 class AnalyticsRulesTest extends TestCase
 {
@@ -26,14 +27,26 @@ class AnalyticsRulesTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        if ($this->isV30OrAbove()) {
+            $this->markTestSkipped('Analytics is deprecated in Typesense v30+');
+        }
+
         $this->ruleUpsertResponse = $this->client()->analytics->rules()->upsert($this->ruleName, $this->ruleConfiguration);
     }
 
     protected function tearDown(): void
     {
-        $rules =  $this->client()->analytics->rules()->retrieve();
-        foreach ($rules['rules'] as $rule) {
-            $this->client()->analytics->rules()->{$rule['name']}->delete();
+        if (!$this->isV30OrAbove()) {
+            try {
+                $rules = $this->client()->analytics->rules()->retrieve();
+                if (is_array($rules) && isset($rules['rules'])) {
+                    foreach ($rules['rules'] as $rule) {
+                        $this->client()->analytics->rules()->{$rule['name']}->delete();
+                    }
+                }
+            } catch (Exception $e) {
+            }
         }
     }
 

--- a/tests/Feature/SynonymSetsTest.php
+++ b/tests/Feature/SynonymSetsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Feature;
+
+use Tests\TestCase;
+use Typesense\Exceptions\ObjectNotFound;
+use Exception;
+
+class SynonymSetsTest extends TestCase
+{
+    private $upsertResponse = null;
+    private $synonymSets = null;
+    private $synonymSetData = [
+        'synonyms' => [
+            [
+                'id' => 'dummy',
+                'synonyms' => ['foo', 'bar', 'baz'],
+                'root' => '',
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        if (!$this->isV30OrAbove()) {
+            $this->markTestSkipped('SynonymSets is only supported in Typesense v30+');
+        }
+        
+        $this->synonymSets = $this->client()->synonymSets;
+        $this->upsertResponse = $this->synonymSets->upsert('test-synonym-set', $this->synonymSetData);
+    }
+
+
+    public function testCanUpsertASynonymSet(): void
+    {
+        $this->assertEquals($this->synonymSetData['synonyms'], $this->upsertResponse['synonyms']);
+    }
+
+    public function testCanRetrieveAllSynonymSets(): void
+    {
+        $returnData = $this->synonymSets->retrieve();
+        $this->assertCount(1, $returnData);
+    }
+
+    public function testCanRetrieveASpecificSynonymSet(): void
+    {
+        $returnData = $this->synonymSets['test-synonym-set']->retrieve();
+        $this->assertEquals($this->synonymSetData['synonyms'], $returnData['synonyms']);
+    }
+
+    public function testCanDeleteASynonymSet(): void
+    {
+        $returnData = $this->synonymSets['test-synonym-set']->delete();
+        $this->assertEquals('test-synonym-set', $returnData['name']);
+
+        $this->expectException(ObjectNotFound::class);
+        $this->synonymSets['test-synonym-set']->retrieve();
+    }
+} 

--- a/tests/Feature/SynonymsTest.php
+++ b/tests/Feature/SynonymsTest.php
@@ -17,6 +17,11 @@ class SynonymsTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+        
+        if ($this->isV30OrAbove()) {
+            $this->markTestSkipped('Synonyms is deprecated in Typesense v30+, use SynonymSets instead');
+        }
+        
         $this->setUpCollection('books');
 
         $this->synonyms = $this->client()->collections['books']->synonyms;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 use Typesense\Client;
 use Mockery;
 use Typesense\ApiCall;
+use Exception;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -96,6 +97,27 @@ abstract class TestCase extends BaseTestCase
         $collections = $this->typesenseClient->collections->retrieve();
         foreach ($collections as $collection) {
             $this->typesenseClient->collections[$collection['name']]->delete();
+        }
+    }
+
+    protected function isV30OrAbove(): bool
+    {
+        try {
+            $debug = $this->typesenseClient->debug->retrieve();
+            $version = $debug['version'];
+            
+            if ($version === 'nightly') {
+                return true;
+            }
+            
+            if (preg_match('/^v(\d+)/', $version, $matches)) {
+                $majorVersion = (int) $matches[1];
+                return $majorVersion >= 30;
+            }
+            
+            return false;
+        } catch (Exception $e) {
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Change Summary
* Add `SynonymSet` and `SynonymSets` classes and register them to the main `Client` object
* Skip old API tests for Synonyms and Analytics
* Add tests to verify Synonym Set behavior

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
