### PR TITLE
Expose the Client::$config and Client::$apiCall properties to subclasses

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -18,7 +18,7 @@ class Client
     /**
      * @var Configuration
      */
-    private Configuration $config;
+    protected Configuration $config;
 
     /**
      * @var Collections
@@ -93,7 +93,7 @@ class Client
     /**
      * @var ApiCall
      */
-    private ApiCall $apiCall;
+    protected ApiCall $apiCall;
 
     /**
      * Client constructor.


### PR DESCRIPTION
## Change Summary
Expose the Client::$config and Client::$apiCall properties to subclasses (change private → protected) so library users can extend Client and inject a customized ApiCall (e.g. for logging, tracing, node selection metrics) without forking the package.

Brief: Change both properties from private to protected so users can subclass Client and swap in a custom ApiCall (e.g. for logging or instrumentation) without forking.

Why: Current private visibility blocks simple customizations; extending requires editing vendor code.

Change:

private Configuration $config -> protected
private ApiCall $apiCall -> protected

Impact: No breaking changes; default behavior unchanged. Enables clean subclass overrides.

Example: The class LoggingClient extends the Client class and includes custom API behavior;
public function __construct(array $options = [])
    {
        parent::__construct($options);
        $this->apiCall = new LoggingApiCall($this->config);
    }

Tests: Existing tests still valid; optional new test can assert subclass receives custom ApiCall.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
