### PR TITLE
fix(dist): only distribute necessary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,10 @@
-/examples       export-ignore
-.gitattributes  export-ignore
-.gitignore      export-ignore
-phpcs.xml       export-ignore
+# This file was partly modified by the lean package validator (http://git.io/lean-package-validator).
+
+.gitattributes   export-ignore
+.github/ 	     export-ignore
+.gitignore       export-ignore
+examples/        export-ignore
+phpcs.xml        export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore
+tests/           export-ignore


### PR DESCRIPTION
Keeps unecessary files (e.g. tests/ and PHPUnit configuration) out of the via Composer installed package (see Git [documentation](https://git-scm.com/docs/gitattributes#_creating_an_archive)).

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
