### PR TITLE
Feat: Add support for /operations/schema_changes endpoint

### DIFF
--- a/src/Operations.php
+++ b/src/Operations.php
@@ -52,6 +52,6 @@ class Operations
      */
     public function getSchemaChangeStatus(): array
     {
-        return $this->apiCall->get(sprintf('%s/%s', static::RESOURCE_PATH, 'schema_changes')
+        return $this->apiCall->get(sprintf('%s/%s', static::RESOURCE_PATH, 'schema_changes'), []);
     }
 }

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -45,4 +45,13 @@ class Operations
             $queryParameters
         );
     }
+
+    /**
+     * @return array
+     * @throws TypesenseClientError|HttpClientException
+     */
+    public function getSchemaChangeStatus(): array
+    {
+        return $this->apiCall->get(sprintf('%s/%s', static::RESOURCE_PATH, 'schema_changes')
+    }
 }


### PR DESCRIPTION
## Change Summary

Basic implementation for the schema changes endpoint, where you'd check a collection schema update's status: https://typesense.org/docs/29.0/api/collections.html#get-schema-change-status

From a skim of the repo I hadn't found a similar usage of adding a subpath under the `RESOURCE_PATH`, so just made a best-guess effort.

Tested these changes in a Laravel repo I'm working with. Cropped to exclude any potential business info:

<img width="148" height="217" alt="Screenshot 2025-12-01 at 11 44 09" src="https://github.com/user-attachments/assets/4bfe281c-1388-468a-86f9-f9ab2f3c442e" />

## PR Checklist
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
