### PR TITLE
Support int, float and bool values for FilterBy escape

### DIFF
--- a/src/FilterBy.php
+++ b/src/FilterBy.php
@@ -4,8 +4,12 @@ namespace Typesense;
 
 class FilterBy
 {
-    public static function escapeString(string $value): string
+    private function escape(string|int|float|bool $value): string
     {
-        return '`' . str_replace('`', '\\`', $value) . '`';
+        return match (true) {
+            is_string($value) => '`' . str_replace('`', '\\`', $value) . '`',
+            is_bool($value) => $value ? 'true' : 'false',
+            default => (string) $value,
+        };
     }
 }

--- a/src/FilterBy.php
+++ b/src/FilterBy.php
@@ -4,7 +4,7 @@ namespace Typesense;
 
 class FilterBy
 {
-    private function escape(string|int|float|bool $value): string
+    public static function escape(string|int|float|bool $value): string
     {
         return match (true) {
             is_string($value) => '`' . str_replace('`', '\\`', $value) . '`',

--- a/tests/Feature/FilterByTest.php
+++ b/tests/Feature/FilterByTest.php
@@ -11,7 +11,7 @@ class FilterByTest extends TestCase
     {
         $rawFilterValue = "The 17\" O'Conner && O`Series \n OR a || 1%2 book? (draft), [alpha]";
 
-        $escapedFilterValue = FilterBy::escapeString($rawFilterValue);
+        $escapedFilterValue = FilterBy::escape($rawFilterValue);
 
         $this->assertSame(
             "`The 17\" O'Conner && O\\`Series \n OR a || 1%2 book? (draft), [alpha]`",
@@ -21,8 +21,36 @@ class FilterByTest extends TestCase
 
     public function testEscapesMultipleBackticksWithinAFilterString(): void
     {
-        $escapedFilterValue = FilterBy::escapeString('`left` and `right`');
+        $escapedFilterValue = FilterBy::escape('`left` and `right`');
 
         $this->assertSame('`\\`left\\` and \\`right\\``', $escapedFilterValue);
+    }
+
+    public function testEscapeBooleanTrue(): void
+    {
+        $escapedFilterValue = FilterBy::escape(true);
+
+        $this->assertSame('true', $escapedFilterValue);
+    }
+
+    public function testEscapeBooleanFalse(): void
+    {
+        $escapedFilterValue = FilterBy::escape(false);
+
+        $this->assertSame('false', $escapedFilterValue);
+    }
+
+    public function testEscapeFloat(): void
+    {
+        $escapedFilterValue = FilterBy::escape(1.12);
+
+        $this->assertSame('1.12', $escapedFilterValue);
+    }
+
+    public function testEscapeInt(): void
+    {
+        $escapedFilterValue = FilterBy::escape(1);
+
+        $this->assertSame('1', $escapedFilterValue);
     }
 }


### PR DESCRIPTION
## Change Summary

Improvement of https://github.com/typesense/typesense-php/pull/115, so bool, int and float are can be handled also. As #115 is not yet released we can rename the method and change to support more.

We used it since a long time in SEAL: https://github.com/PHP-CMSIG/search/blob/5364ad331a0e5caf076e1148f157be0abc06a7dd/packages/seal-typesense-adapter/src/TypesenseSearcher.php#L183-L190

/cc @eyupcanakman @tharropoulos

## PR Checklist

- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
