### PR TITLE
docs: add phpdoc summaries, examples, and docs links to resource classes

### DIFF
--- a/src/Alias.php
+++ b/src/Alias.php
@@ -45,6 +45,13 @@ class Alias
     }
 
     /**
+     * Find out which collection an alias points to by fetching it.
+     *
+     * @example
+     * $client->aliases['my-alias']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/collection-alias.html#retrieve-an-alias
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
@@ -54,6 +61,13 @@ class Alias
     }
 
     /**
+     * Delete an alias.
+     *
+     * @example
+     * $client->aliases['my-alias']->delete()
+     *
+     * @see https://typesense.org/docs/latest/api/collection-alias.html#delete-an-alias
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/Aliases.php
+++ b/src/Aliases.php
@@ -47,6 +47,13 @@ class Aliases implements \ArrayAccess
     }
 
     /**
+     * Create or update an alias mapping for a collection.
+     *
+     * @example
+     * $client->aliases->upsert('my-alias', ['collection_name' => 'products'])
+     *
+     * @see https://typesense.org/docs/latest/api/collection-alias.html#upsert-an-alias
+     *
      * @param string $name
      * @param array $mapping
      *
@@ -59,6 +66,13 @@ class Aliases implements \ArrayAccess
     }
 
     /**
+     * List all aliases and the collections they map to.
+     *
+     * @example
+     * $client->aliases->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/collection-alias.html#list-all-aliases
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -17,6 +17,17 @@ class Analytics
         $this->apiCall = $apiCall;
     }
 
+    /**
+     * Access the analytics rules resource. Use as a method-style endpoint to list or create rules,
+     * or chain `[$id]` on the returned object to access a single rule.
+     *
+     * @example
+     * $client->analytics->rules()->retrieve()
+     * @example
+     * $client->analytics->rules()['rule-1']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
+     */
     public function rules()
     {
         if (!isset($this->rules)) {
@@ -25,6 +36,14 @@ class Analytics
         return $this->rules;
     }
 
+    /**
+     * Access the analytics events resource to send analytics events.
+     *
+     * @example
+     * $client->analytics->events()->create(['type' => 'click', 'name' => 'products_click', 'data' => []])
+     *
+     * @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
+     */
     public function events()
     {
         if (!isset($this->events)) {

--- a/src/AnalyticsEvents.php
+++ b/src/AnalyticsEvents.php
@@ -29,8 +29,13 @@ class AnalyticsEvents
     }
 
     /**
-     * Create an analytics event
-     * 
+     * Submit a single analytics event. The event must correspond to an existing analytics rule by name.
+     *
+     * @example
+     * $client->analytics->events()->create(['type' => 'click', 'name' => 'products_click', 'data' => []])
+     *
+     * @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
+     *
      * @param array $params Event parameters including name, event_type, and data
      * @return array Response from the API
      * @throws TypesenseClientError|HttpClientException
@@ -41,8 +46,13 @@ class AnalyticsEvents
     }
 
     /**
-     * Retrieve analytics events
-     * 
+     * Retrieve the most recent events for a user and rule.
+     *
+     * @example
+     * $client->analytics->events()->retrieve(['user_id' => 'u1', 'name' => 'products_click', 'n' => 10])
+     *
+     * @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
+     *
      * @param array $params Query parameters
      * @return array Response from the API
      */

--- a/src/AnalyticsEventsV1.php
+++ b/src/AnalyticsEventsV1.php
@@ -27,6 +27,13 @@ class AnalyticsEventsV1
     }
 
     /**
+     * Submit a legacy v1 analytics event.
+     *
+     * @example
+     * $client->analyticsV1->events()->create(['type' => 'click', 'name' => 'products_click', 'data' => []])
+     *
+     * @see https://typesense.org/docs/29.0/api/analytics-query-suggestions.html
+     *
      * @param array $params
      *
      * @return array

--- a/src/AnalyticsRule.php
+++ b/src/AnalyticsRule.php
@@ -14,8 +14,13 @@ class AnalyticsRule
     }
 
     /**
-     * Retrieve a specific analytics rule
-     * 
+     * Retrieve the details of an analytics rule, given its name.
+     *
+     * @example
+     * $client->analytics->rules()['rule-1']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
+     *
      * @return array Response from the API
      */
     public function retrieve()
@@ -24,8 +29,13 @@ class AnalyticsRule
     }
 
     /**
-     * Delete a specific analytics rule
-     * 
+     * Permanently deletes an analytics rule, given its name.
+     *
+     * @example
+     * $client->analytics->rules()['rule-1']->delete()
+     *
+     * @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
+     *
      * @return array Response from the API
      */
     public function delete()
@@ -34,8 +44,13 @@ class AnalyticsRule
     }
 
     /**
-     * Update a specific analytics rule
-     * 
+     * Upserts an analytics rule with the given name.
+     *
+     * @example
+     * $client->analytics->rules()['rule-1']->update(['type' => 'popular_queries', 'params' => []])
+     *
+     * @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
+     *
      * @param array $params Rule parameters
      * @return array Response from the API
      */

--- a/src/AnalyticsRuleV1.php
+++ b/src/AnalyticsRuleV1.php
@@ -13,11 +13,27 @@ class AnalyticsRuleV1
         $this->apiCall  = $apiCall;
     }
 
+    /**
+     * Retrieve a legacy v1 analytics rule by name.
+     *
+     * @example
+     * $client->analyticsV1->rules()['rule-1']->retrieve()
+     *
+     * @see https://typesense.org/docs/29.0/api/analytics-query-suggestions.html
+     */
     public function retrieve()
     {
         return $this->apiCall->get($this->endpointPath(), []);
     }
 
+    /**
+     * Delete a legacy v1 analytics rule by name.
+     *
+     * @example
+     * $client->analyticsV1->rules()['rule-1']->delete()
+     *
+     * @see https://typesense.org/docs/29.0/api/analytics-query-suggestions.html
+     */
     public function delete()
     {
         return $this->apiCall->delete($this->endpointPath());

--- a/src/AnalyticsRules.php
+++ b/src/AnalyticsRules.php
@@ -19,8 +19,13 @@ class AnalyticsRules implements \ArrayAccess
     }
 
     /**
-     * Create multiple analytics rules
-     * 
+     * Create one or more analytics rules. You can send a single rule object or an array of rule objects.
+     *
+     * @example
+     * $client->analytics->rules()->create(['name' => 'products_query_hits', 'type' => 'popular_queries', 'params' => []])
+     *
+     * @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
+     *
      * @param array $rules Array of rule objects
      * @return array Response from the API
      */
@@ -30,8 +35,13 @@ class AnalyticsRules implements \ArrayAccess
     }
 
     /**
-     * Retrieve all analytics rules
-     * 
+     * Retrieve all analytics rules.
+     *
+     * @example
+     * $client->analytics->rules()->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
+     *
      * @return array Response from the API
      */
     public function retrieve()

--- a/src/AnalyticsRulesV1.php
+++ b/src/AnalyticsRulesV1.php
@@ -22,11 +22,27 @@ class AnalyticsRulesV1 implements \ArrayAccess
         return $this->analyticsRules[$ruleName];
     }
 
+    /**
+     * Upsert a legacy v1 analytics rule by name.
+     *
+     * @example
+     * $client->analyticsV1->rules()->upsert('products_query_hits', ['type' => 'popular_queries', 'params' => []])
+     *
+     * @see https://typesense.org/docs/29.0/api/analytics-query-suggestions.html
+     */
     public function upsert($ruleName, $params)
     {
         return $this->apiCall->put($this->endpoint_path($ruleName), $params);
     }
 
+    /**
+     * Retrieve all legacy v1 analytics rules.
+     *
+     * @example
+     * $client->analyticsV1->rules()->retrieve()
+     *
+     * @see https://typesense.org/docs/29.0/api/analytics-query-suggestions.html
+     */
     public function retrieve()
     {
         return $this->apiCall->get($this->endpoint_path(), []);

--- a/src/AnalyticsV1.php
+++ b/src/AnalyticsV1.php
@@ -2,6 +2,9 @@
 
 namespace Typesense;
 
+/**
+ * @deprecated Deprecated starting with Typesense Server v30. Please migrate to `$client->analytics` (new Analytics APIs).
+ */
 class AnalyticsV1
 {
     const RESOURCE_PATH = '/analytics';
@@ -17,6 +20,19 @@ class AnalyticsV1
         $this->apiCall = $apiCall;
     }
 
+    /**
+     * Access the legacy v1 analytics rules resource. Use as a method-style endpoint to list or upsert rules,
+     * or chain `[$id]` on the returned object to access a single rule.
+     *
+     * @example
+     * $client->analyticsV1->rules()->retrieve()
+     * @example
+     * $client->analyticsV1->rules()['rule-1']->retrieve()
+     *
+     * @see https://typesense.org/docs/29.0/api/analytics-query-suggestions.html
+     *
+     * @deprecated Deprecated starting with Typesense Server v30. Please migrate to `$client->analytics` (new Analytics APIs).
+     */
     public function rules()
     {
         if (!isset($this->rules)) {
@@ -25,6 +41,16 @@ class AnalyticsV1
         return $this->rules;
     }
 
+    /**
+     * Access the legacy v1 analytics events resource to send analytics events.
+     *
+     * @example
+     * $client->analyticsV1->events()->create(['type' => 'click', 'name' => 'products_click', 'data' => []])
+     *
+     * @see https://typesense.org/docs/29.0/api/analytics-query-suggestions.html
+     *
+     * @deprecated Deprecated starting with Typesense Server v30. Please migrate to `$client->analytics` (new Analytics APIs).
+     */
     public function events()
     {
         if (!isset($this->events)) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,7 +7,9 @@ use Typesense\Lib\Configuration;
 
 include('utils/utils.php');
 /**
- * Class Client
+ * Typesense client for indexing, searching, and managing collections.
+ *
+ * @see https://typesense.org/docs/latest/api/
  *
  * @package \Typesense
  * @date    4/5/20
@@ -21,86 +23,228 @@ class Client
     private Configuration $config;
 
     /**
+     * Access the collections resource. Use as a method-style endpoint to list or create collections,
+     * or as an array to access a single collection by name.
+     *
+     * @example
+     * $client->collections->create(['name' => 'products', 'fields' => [['name' => 'title', 'type' => 'string']]])
+     * @example
+     * $client->collections['products']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/collections.html
+     *
      * @var Collections
      */
     public Collections $collections;
 
     /**
+     * Manage stopwords sets used at query time.
+     *
+     * @example
+     * $client->stopwords->put(['name' => 'en', 'stopwords' => ['a', 'the']])
+     *
+     * @see https://typesense.org/docs/latest/api/stopwords.html
+     *
      * @var Stopwords
      */
     public Stopwords $stopwords;
 
     /**
+     * Access the aliases resource. Use it to upsert or list aliases, or as an array
+     * to access a single alias by name.
+     *
+     * @example
+     * $client->aliases->upsert('my-alias', ['collection_name' => 'products'])
+     * @example
+     * $client->aliases['my-alias']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/collection-alias.html
+     *
      * @var Aliases
      */
     public Aliases $aliases;
 
     /**
+     * Access the API keys resource. Use it to create or list keys, or as an array
+     * to access a single key by ID.
+     *
+     * @example
+     * $client->keys->create(['description' => 'Search-only key', 'actions' => ['documents:search'], 'collections' => ['*']])
+     * @example
+     * $client->keys[1]->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/api-keys.html
+     *
      * @var Keys
      */
     public Keys $keys;
 
     /**
+     * Retrieve server version and state information.
+     *
+     * @example
+     * $client->debug->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/cluster-operations.html#debug
+     *
      * @var Debug
      */
     public Debug $debug;
 
     /**
+     * Get current RAM, CPU, Disk & Network usage metrics.
+     *
+     * @example
+     * $client->metrics->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/cluster-operations.html
+     *
      * @var Metrics
      */
     public Metrics $metrics;
 
     /**
+     * Checks if Typesense server is ready to accept requests.
+     *
+     * @example
+     * $client->health->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/cluster-operations.html#health
+     *
      * @var Health
      */
     public Health $health;
 
     /**
+     * Cluster operations: snapshots, voting, cache, on-disk compaction, slow request log.
+     *
+     * @example
+     * $client->operations->perform('snapshot', ['snapshot_path' => '/tmp/snap'])
+     *
+     * @see https://typesense.org/docs/latest/api/cluster-operations.html
+     *
      * @var Operations
      */
     public Operations $operations;
 
     /**
+     * Send multiple search requests in a single HTTP request.
+     *
+     * @example
+     * $client->multiSearch->perform(['searches' => [['collection' => 'products', 'q' => '*']]])
+     *
+     * @see https://typesense.org/docs/latest/api/documents.html#federated-multi-search
+     *
      * @var MultiSearch
      */
     public MultiSearch $multiSearch;
 
     /**
+     * Access the presets resource. Use it to upsert or list presets, or as an array
+     * to access a single preset by name.
+     *
+     * @example
+     * $client->presets->upsert('listing_view', ['value' => ['q' => '*']])
+     * @example
+     * $client->presets['listing_view']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/search.html#presets
+     *
      * @var Presets
      */
     public Presets $presets;
 
     /**
+     * Legacy v1 analytics API for rules and events.
+     *
+     * @example
+     * $client->analyticsV1->rules()->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
+     *
      * @var AnalyticsV1
      */
     public AnalyticsV1 $analyticsV1;
 
     /**
+     * Manage analytics rules and events.
+     *
+     * @example
+     * $client->analytics->rules()->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/analytics-query-suggestions.html
+     *
      * @var Analytics
      */
     public Analytics $analytics;
 
     /**
+     * Manage stemming dictionaries.
+     *
+     * @example
+     * $client->stemming->dictionaries()->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/stemming.html
+     *
      * @var Stemming
      */
     public Stemming $stemming;
 
     /**
+     * Access the conversation models resource and individual conversations.
+     *
+     * @example
+     * $client->conversations->typesenseModels->retrieve()
+     * @example
+     * $client->conversations['conv-1']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/conversational-search-rag.html
+     *
      * @var Conversations
      */
     public Conversations $conversations;
 
     /**
+     * Access the NL search models resource. Use it to create or list models, or as an array
+     * to access a single model by ID.
+     *
+     * @example
+     * $client->nlSearchModels->create(['model_name' => 'openai/gpt-4'])
+     * @example
+     * $client->nlSearchModels['model-1']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/natural-language-search.html
+     *
      * @var NLSearchModels
      */
     public NLSearchModels $nlSearchModels;
 
     /**
+     * Access the synonym sets resource. Use it to upsert or list sets, or as an array
+     * to access a single set by name.
+     *
+     * @example
+     * $client->synonymSets->retrieve()
+     * @example
+     * $client->synonymSets['my-set']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/synonyms.html
+     *
      * @var SynonymSets
      */
     public SynonymSets $synonymSets;
 
     /**
+     * Access the curation sets resource. Use it to upsert or list sets, or as an array
+     * to access a single set by name.
+     *
+     * @example
+     * $client->curationSets->retrieve()
+     * @example
+     * $client->curationSets['my-set']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/curation.html
+     *
      * @var CurationSets
      */
     public CurationSets $curationSets;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -25,16 +25,46 @@ class Collection
     private ApiCall $apiCall;
 
     /**
+     * Access the documents resource for this collection. Use as a method-style endpoint
+     * to index, search, import or export documents, or as an array to access a single document.
+     *
+     * @example
+     * $client->collections['products']->documents->create(['id' => '1', 'title' => 'Hat'])
+     * @example
+     * $client->collections['products']->documents['1']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/documents.html
+     *
      * @var Documents
      */
     public Documents $documents;
 
     /**
+     * Access the legacy overrides (curation rules) for this collection. Use it to upsert
+     * or list overrides, or as an array to access a single override by ID.
+     *
+     * @example
+     * $client->collections['products']->overrides->upsert('promote-hat', ['rule' => ['query' => 'hat', 'match' => 'exact'], 'includes' => []])
+     * @example
+     * $client->collections['products']->overrides['promote-hat']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/curation.html
+     *
      * @var Overrides
      */
     public Overrides $overrides;
 
     /**
+     * Access the legacy synonyms for this collection. Use it to upsert or list synonyms,
+     * or as an array to access a single synonym by ID.
+     *
+     * @example
+     * $client->collections['products']->synonyms->upsert('syn-1', ['synonyms' => ['nyc', 'new york']])
+     * @example
+     * $client->collections['products']->synonyms['syn-1']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/synonyms.html
+     *
      * @var Synonyms
      */
     public Synonyms $synonyms;
@@ -121,6 +151,13 @@ class Collection
     }
 
     /**
+     * Retrieve the details of a collection, given its name.
+     *
+     * @example
+     * $client->collections['products']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/collections.html#retrieve-a-collection
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
@@ -130,6 +167,13 @@ class Collection
     }
 
     /**
+     * Update a collection's schema to modify the fields and their types.
+     *
+     * @example
+     * $client->collections['products']->update(['fields' => [['name' => 'tags', 'type' => 'string[]']]])
+     *
+     * @see https://typesense.org/docs/latest/api/collections.html#update-or-alter-a-collection
+     *
      * @param array $schema
      *
      * @return array
@@ -141,6 +185,14 @@ class Collection
     }
 
     /**
+     * Permanently drops a collection. This action cannot be undone. For large collections,
+     * this might have an impact on read latencies.
+     *
+     * @example
+     * $client->collections['products']->delete()
+     *
+     * @see https://typesense.org/docs/latest/api/collections.html#drop-a-collection
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/Collections.php
+++ b/src/Collections.php
@@ -54,6 +54,13 @@ class Collections implements \ArrayAccess
     }
 
     /**
+     * When a collection is created, we give it a name and describe the fields that will be indexed from the documents added to the collection.
+     *
+     * @example
+     * $client->collections->create(['name' => 'products', 'fields' => [['name' => 'title', 'type' => 'string']]])
+     *
+     * @see https://typesense.org/docs/latest/api/collections.html#create-a-collection
+     *
      * @param array $schema
      * @param array $options
      *
@@ -66,6 +73,13 @@ class Collections implements \ArrayAccess
     }
 
     /**
+     * Returns a summary of all your collections. The collections are returned sorted by creation date, with the most recent collections appearing first.
+     *
+     * @example
+     * $client->collections->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/collections.html#list-all-collections
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/Conversation.php
+++ b/src/Conversation.php
@@ -35,6 +35,13 @@ class Conversation
     }
 
     /**
+     * Update a conversation's TTL.
+     *
+     * @example
+     * $client->conversations['conv-1']->update(['ttl' => 3600])
+     *
+     * @see https://typesense.org/docs/latest/api/conversational-search-rag.html
+     *
      * @param array $params
      *
      * @return array
@@ -46,6 +53,13 @@ class Conversation
     }
 
     /**
+     * Retrieve a conversation by ID.
+     *
+     * @example
+     * $client->conversations['conv-1']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/conversational-search-rag.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
@@ -55,6 +69,13 @@ class Conversation
     }
 
     /**
+     * Delete a conversation by ID.
+     *
+     * @example
+     * $client->conversations['conv-1']->delete()
+     *
+     * @see https://typesense.org/docs/latest/api/conversational-search-rag.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/ConversationModel.php
+++ b/src/ConversationModel.php
@@ -35,6 +35,13 @@ class ConversationModel
     }
 
     /**
+     * Update a conversation model.
+     *
+     * @example
+     * $client->conversations->typesenseModels['model-1']->update(['model_name' => 'openai/gpt-4', 'max_bytes' => 16384])
+     *
+     * @see https://typesense.org/docs/latest/api/conversational-search-rag.html
+     *
      * @param array $params
      *
      * @return array
@@ -46,6 +53,13 @@ class ConversationModel
     }
 
     /**
+     * Retrieve a conversation model.
+     *
+     * @example
+     * $client->conversations->typesenseModels['model-1']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/conversational-search-rag.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
@@ -55,6 +69,13 @@ class ConversationModel
     }
 
     /**
+     * Delete a conversation model.
+     *
+     * @example
+     * $client->conversations->typesenseModels['model-1']->delete()
+     *
+     * @see https://typesense.org/docs/latest/api/conversational-search-rag.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/ConversationModels.php
+++ b/src/ConversationModels.php
@@ -52,6 +52,13 @@ class ConversationModels implements \ArrayAccess
     }
 
     /**
+     * Create a Conversation Model.
+     *
+     * @example
+     * $client->conversations->typesenseModels->create(['model_name' => 'openai/gpt-4', 'api_key' => '...'])
+     *
+     * @see https://typesense.org/docs/latest/api/conversational-search-rag.html
+     *
      * @param array $params
      *
      * @return array
@@ -63,6 +70,13 @@ class ConversationModels implements \ArrayAccess
     }
 
     /**
+     * Retrieve all conversation models.
+     *
+     * @example
+     * $client->conversations->typesenseModels->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/conversational-search-rag.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/Conversations.php
+++ b/src/Conversations.php
@@ -12,6 +12,16 @@ class Conversations implements \ArrayAccess
     public const RESOURCE_PATH = '/conversations';
 
     /**
+     * Access the conversation models resource. Use it to create or list models, or as an array
+     * to access a single model by ID.
+     *
+     * @example
+     * $client->conversations->typesenseModels->create(['model_name' => 'openai/gpt-4', 'api_key' => '...'])
+     * @example
+     * $client->conversations->typesenseModels['model-1']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/conversational-search-rag.html
+     *
      * @var ConversationModels
      */
     public ConversationModels $typesenseModels;

--- a/src/CurationSet.php
+++ b/src/CurationSet.php
@@ -67,6 +67,13 @@ class CurationSet
     }
 
     /**
+     * Create or update a curation set with the given name.
+     *
+     * @example
+     * $client->curationSets['my-set']->upsert(['items' => [['id' => 'promote-hat', 'rule' => ['query' => 'hat', 'match' => 'exact']]]])
+     *
+     * @see https://typesense.org/docs/latest/api/curation.html
+     *
      * @param array $params
      *
      * @return array
@@ -78,6 +85,13 @@ class CurationSet
     }
 
     /**
+     * Retrieve a specific curation set by its name.
+     *
+     * @example
+     * $client->curationSets['my-set']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/curation.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
@@ -87,6 +101,13 @@ class CurationSet
     }
 
     /**
+     * Delete a specific curation set by its name.
+     *
+     * @example
+     * $client->curationSets['my-set']->delete()
+     *
+     * @see https://typesense.org/docs/latest/api/curation.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
@@ -96,6 +117,16 @@ class CurationSet
     }
 
     /**
+     * Access the items in this curation set. Use the returned object as an array to access
+     * a single item by ID, or call `retrieve()` to list all items.
+     *
+     * @example
+     * $client->curationSets['my-set']->getItems()->retrieve()
+     * @example
+     * $client->curationSets['my-set']->getItems()['promote-hat']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/curation.html
+     *
      * @return CurationSetItems
      */
     public function getItems(): CurationSetItems

--- a/src/CurationSetItem.php
+++ b/src/CurationSetItem.php
@@ -55,6 +55,13 @@ class CurationSetItem
     }
 
     /**
+     * Retrieve a specific curation item by its id.
+     *
+     * @example
+     * $client->curationSets['my-set']->getItems()['promote-hat']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/curation.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
@@ -64,6 +71,13 @@ class CurationSetItem
     }
 
     /**
+     * Create or update a curation set item with the given id.
+     *
+     * @example
+     * $client->curationSets['my-set']->getItems()['promote-hat']->upsert(['rule' => ['query' => 'hat', 'match' => 'exact'], 'includes' => []])
+     *
+     * @see https://typesense.org/docs/latest/api/curation.html
+     *
      * @param array $params
      *
      * @return array
@@ -75,6 +89,13 @@ class CurationSetItem
     }
 
     /**
+     * Delete a specific curation item by its id.
+     *
+     * @example
+     * $client->curationSets['my-set']->getItems()['promote-hat']->delete()
+     *
+     * @see https://typesense.org/docs/latest/api/curation.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/CurationSetItems.php
+++ b/src/CurationSetItems.php
@@ -52,6 +52,13 @@ class CurationSetItems implements \ArrayAccess
     }
 
     /**
+     * Retrieve all curation items in a set.
+     *
+     * @example
+     * $client->curationSets['my-set']->getItems()->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/curation.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/CurationSets.php
+++ b/src/CurationSets.php
@@ -35,6 +35,13 @@ class CurationSets implements \ArrayAccess
     }
 
     /**
+     * Create or update a curation set with the given name.
+     *
+     * @example
+     * $client->curationSets->upsert('my-set', ['items' => [['id' => 'promote-hat', 'rule' => ['query' => 'hat', 'match' => 'exact']]]])
+     *
+     * @see https://typesense.org/docs/latest/api/curation.html
+     *
      * @param string $curationSetName
      * @param array $config
      *
@@ -47,6 +54,13 @@ class CurationSets implements \ArrayAccess
     }
 
     /**
+     * Retrieve all curation sets.
+     *
+     * @example
+     * $client->curationSets->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/curation.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/Debug.php
+++ b/src/Debug.php
@@ -31,6 +31,13 @@ class Debug
     }
 
     /**
+     * Retrieve server version and state information.
+     *
+     * @example
+     * $client->debug->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/cluster-operations.html#debug
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/Document.php
+++ b/src/Document.php
@@ -58,6 +58,13 @@ class Document
     }
 
     /**
+     * Fetch an individual document from a collection by using its ID.
+     *
+     * @example
+     * $client->collections['products']->documents['1']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/documents.html#retrieve-a-document
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
@@ -67,6 +74,13 @@ class Document
     }
 
     /**
+     * Update an individual document by ID by merging the provided fields.
+     *
+     * @example
+     * $client->collections['products']->documents['1']->update(['in_stock' => true])
+     *
+     * @see https://typesense.org/docs/latest/api/documents.html#update-a-document
+     *
      * @param array $partialDocument
      * @param array $options
      *
@@ -79,6 +93,13 @@ class Document
     }
 
     /**
+     * Delete an individual document from a collection by using its ID.
+     *
+     * @example
+     * $client->collections['products']->documents['1']->delete()
+     *
+     * @see https://typesense.org/docs/latest/api/documents.html#delete-a-document
+     *
      * @param array $options
      * @return array
      * @throws TypesenseClientError|HttpClientException

--- a/src/Documents.php
+++ b/src/Documents.php
@@ -60,6 +60,13 @@ class Documents implements \ArrayAccess
     }
 
     /**
+     * Index a single document. The document must conform to the schema of the collection.
+     *
+     * @example
+     * $client->collections['products']->documents->create(['id' => '1', 'title' => 'Hat'])
+     *
+     * @see https://typesense.org/docs/latest/api/documents.html#index-a-single-document
+     *
      * @param array $document
      * @param array $options
      *
@@ -72,6 +79,13 @@ class Documents implements \ArrayAccess
     }
 
     /**
+     * Upsert a single document. Creates the document if it does not exist, otherwise updates it.
+     *
+     * @example
+     * $client->collections['products']->documents->upsert(['id' => '1', 'title' => 'Hat'])
+     *
+     * @see https://typesense.org/docs/latest/api/documents.html#upsert
+     *
      * @param array $document
      * @param array $options
      *
@@ -89,6 +103,16 @@ class Documents implements \ArrayAccess
     }
 
     /**
+     * Update documents matching a `filter_by` condition, or update a single document with
+     * `action: "update"` semantics.
+     *
+     * @example
+     * $client->collections['products']->documents->update(['in_stock' => true], ['filter_by' => 'category:=hats'])
+     * @example
+     * $client->collections['products']->documents->update(['id' => '1', 'title' => 'Hat'])
+     *
+     * @see https://typesense.org/docs/latest/api/documents.html#update-documents-with-conditional-query
+     *
      * @param array $document
      * @param array $options
      *
@@ -131,6 +155,15 @@ class Documents implements \ArrayAccess
     }
 
     /**
+     * Import documents into a collection. Accepts a JSONL string or an array of document objects.
+     *
+     * @example
+     * $client->collections['products']->documents->import([['id' => '1', 'title' => 'Hat'], ['id' => '2', 'title' => 'Shirt']])
+     * @example
+     * $client->collections['products']->documents->import($jsonlString)
+     *
+     * @see https://typesense.org/docs/latest/api/documents.html#index-multiple-documents
+     *
      * @param string|array $documents
      * @param array $options
      *
@@ -168,6 +201,13 @@ class Documents implements \ArrayAccess
     }
 
     /**
+     * Export all documents in a collection as a JSONL string.
+     *
+     * @example
+     * $client->collections['products']->documents->export()
+     *
+     * @see https://typesense.org/docs/latest/api/documents.html#export-documents
+     *
      * @param array $queryParams
      *
      * @return string
@@ -179,6 +219,16 @@ class Documents implements \ArrayAccess
     }
 
     /**
+     * Delete a bunch of documents that match a specific filter condition,
+     * or truncate the collection.
+     *
+     * @example
+     * $client->collections['products']->documents->delete(['filter_by' => 'in_stock:=false'])
+     * @example
+     * $client->collections['products']->documents->delete(['truncate' => true])
+     *
+     * @see https://typesense.org/docs/latest/api/documents.html#delete-by-query
+     *
      * @param array $queryParams
      *
      * @return array
@@ -190,6 +240,13 @@ class Documents implements \ArrayAccess
     }
 
     /**
+     * Search for documents in this collection.
+     *
+     * @example
+     * $client->collections['products']->documents->search(['q' => '*'])
+     *
+     * @see https://typesense.org/docs/latest/api/documents.html#search
+     *
      * @param array $searchParams
      *
      * @return array

--- a/src/Health.php
+++ b/src/Health.php
@@ -31,6 +31,13 @@ class Health
     }
 
     /**
+     * Checks if Typesense server is ready to accept requests.
+     *
+     * @example
+     * $client->health->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/cluster-operations.html#health
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/Key.php
+++ b/src/Key.php
@@ -45,6 +45,13 @@ class Key
     }
 
     /**
+     * Retrieve (metadata about) a key. Only the key prefix is returned when you retrieve a key. Due to security reasons, only the create endpoint returns the full API key.
+     *
+     * @example
+     * $client->keys[1]->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/api-keys.html#retrieve-an-api-key
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
@@ -54,6 +61,13 @@ class Key
     }
 
     /**
+     * Delete an API key given its ID.
+     *
+     * @example
+     * $client->keys[1]->delete()
+     *
+     * @see https://typesense.org/docs/latest/api/api-keys.html#delete-api-key
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/Keys.php
+++ b/src/Keys.php
@@ -37,6 +37,13 @@ class Keys implements \ArrayAccess
     }
 
     /**
+     * Create an API Key with fine-grain access control. You can restrict access on both a per-collection and per-action level. The generated key is returned only during creation. You want to store this key carefully in a secure place.
+     *
+     * @example
+     * $client->keys->create(['description' => 'Search-only key', 'actions' => ['documents:search'], 'collections' => ['*']])
+     *
+     * @see https://typesense.org/docs/latest/api/api-keys.html#create-an-api-key
+     *
      * @param array $schema
      *
      * @return array
@@ -48,6 +55,13 @@ class Keys implements \ArrayAccess
     }
 
     /**
+     * Generate a scoped search-only API key with embedded parameters such as `filter_by` or `expires_at`.
+     *
+     * @example
+     * $client->keys->generateScopedSearchKey('xyz', ['filter_by' => 'company_id:124'])
+     *
+     * @see https://typesense.org/docs/latest/api/api-keys.html#generate-scoped-search-key
+     *
      * @param string $searchKey
      * @param array $parameters
      *
@@ -78,6 +92,13 @@ class Keys implements \ArrayAccess
     }
 
     /**
+     * Retrieve (metadata about) all keys.
+     *
+     * @example
+     * $client->keys->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/api-keys.html#list-all-keys
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/Metrics.php
+++ b/src/Metrics.php
@@ -31,6 +31,13 @@ class Metrics
     }
 
     /**
+     * Get current RAM, CPU, Disk & Network usage metrics.
+     *
+     * @example
+     * $client->metrics->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/cluster-operations.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/MultiSearch.php
+++ b/src/MultiSearch.php
@@ -30,6 +30,15 @@ class MultiSearch
     }
 
     /**
+     * Send multiple search requests in a single HTTP request. Pass `union: true` to merge results, or omit it to receive a `results` array.
+     *
+     * @example
+     * $client->multiSearch->perform(['searches' => [['collection' => 'products', 'q' => '*']]])
+     * @example
+     * $client->multiSearch->perform(['union' => true, 'searches' => [['collection' => 'products', 'q' => '*']]])
+     *
+     * @see https://typesense.org/docs/latest/api/documents.html#federated-multi-search
+     *
      * @param array $searches
      * @param array $queryParameters
      *

--- a/src/NLSearchModel.php
+++ b/src/NLSearchModel.php
@@ -35,6 +35,13 @@ class NLSearchModel
     }
 
     /**
+     * Update an existing NL search model.
+     *
+     * @example
+     * $client->nlSearchModels['model-1']->update(['model_name' => 'openai/gpt-4'])
+     *
+     * @see https://typesense.org/docs/latest/api/natural-language-search.html
+     *
      * @param array $params
      *
      * @return array
@@ -46,6 +53,13 @@ class NLSearchModel
     }
 
     /**
+     * Retrieve a specific NL search model by its ID.
+     *
+     * @example
+     * $client->nlSearchModels['model-1']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/natural-language-search.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
@@ -55,6 +69,13 @@ class NLSearchModel
     }
 
     /**
+     * Delete a specific NL search model by its ID.
+     *
+     * @example
+     * $client->nlSearchModels['model-1']->delete()
+     *
+     * @see https://typesense.org/docs/latest/api/natural-language-search.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/NLSearchModels.php
+++ b/src/NLSearchModels.php
@@ -52,6 +52,13 @@ class NLSearchModels implements \ArrayAccess
     }
 
     /**
+     * Create a new NL search model.
+     *
+     * @example
+     * $client->nlSearchModels->create(['model_name' => 'openai/gpt-4', 'api_key' => '...'])
+     *
+     * @see https://typesense.org/docs/latest/api/natural-language-search.html
+     *
      * @param array $params
      *
      * @return array
@@ -63,6 +70,13 @@ class NLSearchModels implements \ArrayAccess
     }
 
     /**
+     * Retrieve all NL search models.
+     *
+     * @example
+     * $client->nlSearchModels->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/natural-language-search.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -30,6 +30,13 @@ class Operations
     }
 
     /**
+     * Perform a cluster operation: snapshot, vote, cache/clear, db/compact, or a custom path.
+     *
+     * @example
+     * $client->operations->perform('snapshot', ['snapshot_path' => '/tmp/snap'])
+     *
+     * @see https://typesense.org/docs/latest/api/cluster-operations.html
+     *
      * @param string $operationName
      * @param array $queryParameters
      *
@@ -47,6 +54,13 @@ class Operations
     }
 
     /**
+     * Get the status of in-progress schema change operations.
+     *
+     * @example
+     * $client->operations->getSchemaChangeStatus()
+     *
+     * @see https://typesense.org/docs/latest/api/cluster-operations.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/Override.php
+++ b/src/Override.php
@@ -58,6 +58,13 @@ class Override
     }
 
     /**
+     * Retrieve an override (curation rule) by ID on this collection.
+     *
+     * @example
+     * $client->collections['products']->overrides['promote-hat']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/curation.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
@@ -67,6 +74,13 @@ class Override
     }
 
     /**
+     * Delete an override (curation rule) by ID on this collection.
+     *
+     * @example
+     * $client->collections['products']->overrides['promote-hat']->delete()
+     *
+     * @see https://typesense.org/docs/latest/api/curation.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/Overrides.php
+++ b/src/Overrides.php
@@ -60,6 +60,13 @@ class Overrides implements \ArrayAccess
     }
 
     /**
+     * Create or update an override (curation rule) on this collection.
+     *
+     * @example
+     * $client->collections['products']->overrides->upsert('promote-hat', ['rule' => ['query' => 'hat', 'match' => 'exact'], 'includes' => []])
+     *
+     * @see https://typesense.org/docs/latest/api/curation.html
+     *
      * @param string $overrideId
      * @param array $config
      *
@@ -72,6 +79,13 @@ class Overrides implements \ArrayAccess
     }
 
     /**
+     * Retrieve all overrides (curation rules) on this collection.
+     *
+     * @example
+     * $client->collections['products']->overrides->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/curation.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/Preset.php
+++ b/src/Preset.php
@@ -35,6 +35,13 @@ class Preset
     }
 
     /**
+     * Retrieve the details of a preset, given its name.
+     *
+     * @example
+     * $client->presets['listing_view']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/search.html#presets
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
@@ -44,6 +51,13 @@ class Preset
     }
 
     /**
+     * Permanently deletes a preset, given its name.
+     *
+     * @example
+     * $client->presets['listing_view']->delete()
+     *
+     * @see https://typesense.org/docs/latest/api/search.html#presets
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/Presets.php
+++ b/src/Presets.php
@@ -39,6 +39,13 @@ class Presets implements \ArrayAccess
     }
 
     /**
+     * Run a multi-search request using a previously saved preset.
+     *
+     * @example
+     * $client->presets->searchWithPreset('listing_view')
+     *
+     * @see https://typesense.org/docs/latest/api/search.html#presets
+     *
      * @param $presetName
      * @return array|string
      * @throws HttpClientException
@@ -50,6 +57,13 @@ class Presets implements \ArrayAccess
     }
 
     /**
+     * Retrieve the details of all presets.
+     *
+     * @example
+     * $client->presets->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/search.html#presets
+     *
      * @return array|string
      * @throws HttpClientException
      * @throws TypesenseClientError
@@ -60,8 +74,15 @@ class Presets implements \ArrayAccess
     }
 
     /**
+     * Create or update an existing preset.
+     *
+     * @example
+     * $client->presets->upsert('listing_view', ['value' => ['q' => '*']])
+     *
+     * @see https://typesense.org/docs/latest/api/search.html#presets
+     *
      * @param string $presetName
-     * @param array $options
+     * @param array $presetsData
      *
      * @return array
      * @throws HttpClientException

--- a/src/Stemming.php
+++ b/src/Stemming.php
@@ -16,6 +16,17 @@ class Stemming
         $this->apiCall = $apiCall;
     }
 
+    /**
+     * Access the stemming dictionaries resource. Use as a method-style endpoint to list or import
+     * dictionaries, or chain `[$id]` on the returned object to access a single dictionary.
+     *
+     * @example
+     * $client->stemming->dictionaries()->retrieve()
+     * @example
+     * $client->stemming->dictionaries()['en']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/stemming.html
+     */
     public function dictionaries()
     {
         if (!isset($this->typesenseDictionaries)) {

--- a/src/StemmingDictionaries.php
+++ b/src/StemmingDictionaries.php
@@ -22,6 +22,14 @@ class StemmingDictionaries implements \ArrayAccess
         return $this->typesenseDictionaries[$id];
     }
 
+    /**
+     * Upload a JSONL file containing word mappings to create or update a stemming dictionary.
+     *
+     * @example
+     * $client->stemming->dictionaries()->upsert('irregular-plurals', [['word' => 'people', 'root' => 'person']])
+     *
+     * @see https://typesense.org/docs/latest/api/stemming.html
+     */
     public function upsert($id, $wordRootCombinations)
     {
         $dictionaryInJSONLFormat = is_array($wordRootCombinations) ? implode(
@@ -45,6 +53,14 @@ class StemmingDictionaries implements \ArrayAccess
         ) : $resultsInJSONLFormat;
     }
 
+    /**
+     * Retrieve a list of all available stemming dictionaries.
+     *
+     * @example
+     * $client->stemming->dictionaries()->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/stemming.html
+     */
     public function retrieve()
     {
         $response = $this->apiCall->get(StemmingDictionaries::RESOURCE_PATH, []);

--- a/src/StemmingDictionary.php
+++ b/src/StemmingDictionary.php
@@ -13,6 +13,14 @@ class StemmingDictionary
         $this->apiCall  = $apiCall;
     }
 
+    /**
+     * Fetch details of a specific stemming dictionary.
+     *
+     * @example
+     * $client->stemming->dictionaries()['en']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/stemming.html
+     */
     public function retrieve()
     {
         return $this->apiCall->get($this->endpointPath(), []);

--- a/src/Stopwords.php
+++ b/src/Stopwords.php
@@ -32,6 +32,13 @@ class Stopwords
     }
 
     /**
+     * Retrieve the details of a stopwords set, given its name.
+     *
+     * @example
+     * $client->stopwords->get('en')
+     *
+     * @see https://typesense.org/docs/latest/api/stopwords.html
+     *
      * @return array|string
      * @throws HttpClientException
      * @throws TypesenseClientError
@@ -45,6 +52,13 @@ class Stopwords
     }
 
     /**
+     * Retrieve the details of all stopwords sets.
+     *
+     * @example
+     * $client->stopwords->getAll()
+     *
+     * @see https://typesense.org/docs/latest/api/stopwords.html
+     *
      * @return array|string
      * @throws HttpClientException
      * @throws TypesenseClientError
@@ -55,6 +69,13 @@ class Stopwords
     }
 
     /**
+     * Upsert a stopwords set. The set's name must be provided as the `name` key on the array.
+     *
+     * @example
+     * $client->stopwords->put(['name' => 'en', 'stopwords' => ['a', 'the']])
+     *
+     * @see https://typesense.org/docs/latest/api/stopwords.html
+     *
      * @param array $stopwordSet
      *
      * @return array
@@ -67,6 +88,13 @@ class Stopwords
     }
 
     /**
+     * Permanently deletes a stopwords set, given its name.
+     *
+     * @example
+     * $client->stopwords->delete('en')
+     *
+     * @see https://typesense.org/docs/latest/api/stopwords.html
+     *
      * @param $stopwordsName
      * @return array
      * @throws HttpClientException

--- a/src/Synonym.php
+++ b/src/Synonym.php
@@ -9,6 +9,8 @@ use Typesense\Exceptions\TypesenseClientError;
  * Class synonym
  *
  * @package \Typesense
+ *
+ * @deprecated Deprecated starting with Typesense Server v30. Please migrate to `$client->synonymSets` (new Synonym Sets APIs).
  */
 class Synonym
 {
@@ -56,6 +58,15 @@ class Synonym
     }
 
     /**
+     * Retrieve a synonym (legacy v1) by ID on this collection.
+     *
+     * @example
+     * $client->collections['products']->synonyms['syn-1']->retrieve()
+     *
+     * @see https://typesense.org/docs/29.0/api/synonyms.html
+     *
+     * @deprecated Deprecated starting with Typesense Server v30. Please migrate to `$client->synonymSets` (new Synonym Sets APIs).
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
@@ -65,6 +76,15 @@ class Synonym
     }
 
     /**
+     * Delete a synonym (legacy v1) by ID on this collection.
+     *
+     * @example
+     * $client->collections['products']->synonyms['syn-1']->delete()
+     *
+     * @see https://typesense.org/docs/29.0/api/synonyms.html
+     *
+     * @deprecated Deprecated starting with Typesense Server v30. Please migrate to `$client->synonymSets` (new Synonym Sets APIs).
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/SynonymSet.php
+++ b/src/SynonymSet.php
@@ -67,6 +67,13 @@ class SynonymSet
     }
 
     /**
+     * Create or update a synonym set with the given name.
+     *
+     * @example
+     * $client->synonymSets['my-set']->upsert(['items' => [['id' => 'syn-1', 'synonyms' => ['nyc', 'new york']]]])
+     *
+     * @see https://typesense.org/docs/latest/api/synonyms.html
+     *
      * @param array $params
      *
      * @return array
@@ -78,6 +85,13 @@ class SynonymSet
     }
 
     /**
+     * Retrieve a specific synonym set by its name.
+     *
+     * @example
+     * $client->synonymSets['my-set']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/synonyms.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
@@ -87,6 +101,13 @@ class SynonymSet
     }
 
     /**
+     * Delete a specific synonym set by its name.
+     *
+     * @example
+     * $client->synonymSets['my-set']->delete()
+     *
+     * @see https://typesense.org/docs/latest/api/synonyms.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
@@ -96,6 +117,16 @@ class SynonymSet
     }
 
     /**
+     * Access the items in this synonym set. Use the returned object as an array to access
+     * a single item by ID, or call `retrieve()` to list all items.
+     *
+     * @example
+     * $client->synonymSets['my-set']->getItems()->retrieve()
+     * @example
+     * $client->synonymSets['my-set']->getItems()['syn-1']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/synonyms.html
+     *
      * @return SynonymSetItems
      */
     public function getItems(): SynonymSetItems

--- a/src/SynonymSetItem.php
+++ b/src/SynonymSetItem.php
@@ -55,6 +55,13 @@ class SynonymSetItem
     }
 
     /**
+     * Retrieve a specific synonym item by its id.
+     *
+     * @example
+     * $client->synonymSets['my-set']->getItems()['syn-1']->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/synonyms.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */
@@ -64,6 +71,13 @@ class SynonymSetItem
     }
 
     /**
+     * Create or update a synonym set item with the given id.
+     *
+     * @example
+     * $client->synonymSets['my-set']->getItems()['syn-1']->upsert(['synonyms' => ['nyc', 'new york']])
+     *
+     * @see https://typesense.org/docs/latest/api/synonyms.html
+     *
      * @param array $params
      *
      * @return array
@@ -75,6 +89,13 @@ class SynonymSetItem
     }
 
     /**
+     * Delete a specific synonym item by its id.
+     *
+     * @example
+     * $client->synonymSets['my-set']->getItems()['syn-1']->delete()
+     *
+     * @see https://typesense.org/docs/latest/api/synonyms.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/SynonymSetItems.php
+++ b/src/SynonymSetItems.php
@@ -52,6 +52,13 @@ class SynonymSetItems implements \ArrayAccess
     }
 
     /**
+     * Retrieve all synonym items in a set.
+     *
+     * @example
+     * $client->synonymSets['my-set']->getItems()->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/synonyms.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/SynonymSets.php
+++ b/src/SynonymSets.php
@@ -35,6 +35,13 @@ class SynonymSets implements \ArrayAccess
     }
 
     /**
+     * Create or update a synonym set with the given name.
+     *
+     * @example
+     * $client->synonymSets->upsert('my-set', ['items' => [['id' => 'syn-1', 'synonyms' => ['nyc', 'new york']]]])
+     *
+     * @see https://typesense.org/docs/latest/api/synonyms.html
+     *
      * @param string $synonymSetName
      * @param array $config
      *
@@ -47,6 +54,13 @@ class SynonymSets implements \ArrayAccess
     }
 
     /**
+     * Retrieve all synonym sets.
+     *
+     * @example
+     * $client->synonymSets->retrieve()
+     *
+     * @see https://typesense.org/docs/latest/api/synonyms.html
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */

--- a/src/Synonyms.php
+++ b/src/Synonyms.php
@@ -9,6 +9,8 @@ use Typesense\Exceptions\TypesenseClientError;
  * Class Synonyms
  *
  * @package \Typesense
+ *
+ * @deprecated Deprecated starting with Typesense Server v30. Please migrate to `$client->synonymSets` (new Synonym Sets APIs).
  */
 class Synonyms implements \ArrayAccess
 {
@@ -58,6 +60,15 @@ class Synonyms implements \ArrayAccess
     }
 
     /**
+     * Create or update a synonym (legacy v1) on this collection.
+     *
+     * @example
+     * $client->collections['products']->synonyms->upsert('syn-1', ['synonyms' => ['nyc', 'new york']])
+     *
+     * @see https://typesense.org/docs/29.0/api/synonyms.html
+     *
+     * @deprecated Deprecated starting with Typesense Server v30. Please migrate to `$client->synonymSets` (new Synonym Sets APIs).
+     *
      * @param string $synonymId
      * @param array $config
      *
@@ -70,6 +81,15 @@ class Synonyms implements \ArrayAccess
     }
 
     /**
+     * Retrieve all synonyms (legacy v1) on this collection.
+     *
+     * @example
+     * $client->collections['products']->synonyms->retrieve()
+     *
+     * @see https://typesense.org/docs/29.0/api/synonyms.html
+     *
+     * @deprecated Deprecated starting with Typesense Server v30. Please migrate to `$client->synonymSets` (new Synonym Sets APIs).
+     *
      * @return array
      * @throws TypesenseClientError|HttpClientException
      */


### PR DESCRIPTION
## Change Summary
add phpdoc with one-line summaries, @example usage snippets, and @see docs links to every resource class in src/, mirroring the wording of the js client's jsdoc. hovering on `$client->keys`, `$client->collections['products']->documents->import(...)`, etc. surfaces the right description, a runnable example, and a link to the relevant docs section. annotate the legacy analytics v1, synonyms, and synonym classes with `@deprecated` pointing to their replacements.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
