### PR TITLE
Add StructArmed to QA

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@ phpcs.xml        export-ignore
 phpunit.xml.dist export-ignore
 README.md        export-ignore
 tests/           export-ignore
+structarmed.php  export-ignore

--- a/.github/workflows/structarmed.yml
+++ b/.github/workflows/structarmed.yml
@@ -1,0 +1,17 @@
+name: StructArmed
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Run StructArmed static analysis with PHP v8.4
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+      - uses: php-actions/composer@v6
+      - name: Run StructArmed
+        run: vendor/bin/structarmed analyze

--- a/.github/workflows/structarmed.yml
+++ b/.github/workflows/structarmed.yml
@@ -13,5 +13,7 @@ jobs:
         with:
           php-version: "8.4"
       - uses: php-actions/composer@v6
+      - name: Include StructArmed
+        run: composer require --dev boundwize/structarmed:^0.10
       - name: Run StructArmed
         run: vendor/bin/structarmed analyze

--- a/.github/workflows/structarmed.yml
+++ b/.github/workflows/structarmed.yml
@@ -20,7 +20,7 @@ jobs:
         run: composer install --no-interaction --prefer-dist
 
       - name: Include StructArmed
-        run: composer require --dev boundwize/structarmed:^0.10 --no-interaction
+        run: composer require --dev boundwize/structarmed:^0.11 --no-interaction
 
       - name: Run StructArmed
         run: vendor/bin/structarmed analyze

--- a/.github/workflows/structarmed.yml
+++ b/.github/workflows/structarmed.yml
@@ -6,14 +6,21 @@ jobs:
   test:
     name: Run StructArmed static analysis with PHP v8.4
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
+
       - name: Setup PHP 8.4
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.4"
-      - uses: php-actions/composer@v6
+          tools: composer
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
       - name: Include StructArmed
-        run: composer require --dev boundwize/structarmed:^0.10
+        run: composer require --dev boundwize/structarmed:^0.10 --no-interaction
+
       - name: Run StructArmed
         run: vendor/bin/structarmed analyze

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
     "phpunit/phpunit": "^11.2",
     "squizlabs/php_codesniffer": "3.*",
     "symfony/http-client": "^5.2",
-    "mockery/mockery": "^1.6"
+    "mockery/mockery": "^1.6",
+    "boundwize/structarmed": "^0.10.1"
   },
   "config": {
     "optimize-autoloader": true,

--- a/composer.json
+++ b/composer.json
@@ -50,8 +50,7 @@
     "phpunit/phpunit": "^11.2",
     "squizlabs/php_codesniffer": "3.*",
     "symfony/http-client": "^5.2",
-    "mockery/mockery": "^1.6",
-    "boundwize/structarmed": "^0.10.1"
+    "mockery/mockery": "^1.6"
   },
   "config": {
     "optimize-autoloader": true,

--- a/structarmed.php
+++ b/structarmed.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\Preset\Preset;
+
+return Architecture::define()
+    ->withPreset(Preset::PSR4());

--- a/tests/Feature/AliasesTest.php
+++ b/tests/Feature/AliasesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\Exceptions\ObjectNotFound;

--- a/tests/Feature/AnalyticsEventsTest.php
+++ b/tests/Feature/AnalyticsEventsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Exception;
@@ -127,7 +127,7 @@ class AnalyticsEventsTest extends TestCase
                 "user_id" => "test_user"
             ]
         ];
-        
+
         $this->client()->analytics->events()->create($event);
 
         $response = $this->client()->analytics->events()->retrieve([
@@ -165,4 +165,4 @@ class AnalyticsEventsTest extends TestCase
         $conversionResponse = $this->client()->analytics->events()->create($conversionEvent);
         $this->assertIsArray($conversionResponse);
     }
-} 
+}

--- a/tests/Feature/AnalyticsEventsV1Test.php
+++ b/tests/Feature/AnalyticsEventsV1Test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Exception;
@@ -12,11 +12,11 @@ class AnalyticsEventsV1Test extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         if ($this->isV30OrAbove()) {
             $this->markTestSkipped('Analytics is deprecated in Typesense v30+');
         }
-        
+
         $this->client()->collections->create([
             "name" => "products",
             "fields" => [
@@ -58,7 +58,7 @@ class AnalyticsEventsV1Test extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
-        
+
         if (!$this->isV30OrAbove()) {
             try {
                 $this->client()->analyticsV1->rules()->{'product_queries_aggregation'}->delete();

--- a/tests/Feature/AnalyticsRulesTest.php
+++ b/tests/Feature/AnalyticsRulesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\Exceptions\RequestMalformed;
@@ -105,10 +105,10 @@ class AnalyticsRulesTest extends TestCase
 
         $response = $this->client()->analytics->rules()->create($rules);
         $this->assertIsArray($response);
-        
+
         $allRules = $this->client()->analytics->rules()->retrieve();
         $this->assertIsArray($allRules);
-        
+
         $ruleNames = array_column($allRules, 'name');
         $this->assertContains('test_rule_1', $ruleNames);
         $this->assertContains('test_rule_2', $ruleNames);
@@ -161,10 +161,10 @@ class AnalyticsRulesTest extends TestCase
     {
         $rule = $this->client()->analytics->rules()[$this->ruleName];
         $this->assertInstanceOf('Typesense\AnalyticsRule', $rule);
-        
+
         $this->assertTrue(isset($this->client()->analytics->rules()[$this->ruleName]));
-        
+
         $rule = $this->client()->analytics->rules()[$this->ruleName];
         $this->assertInstanceOf('Typesense\AnalyticsRule', $rule);
     }
-} 
+}

--- a/tests/Feature/AnalyticsRulesV1Test.php
+++ b/tests/Feature/AnalyticsRulesV1Test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\Exceptions\ObjectNotFound;

--- a/tests/Feature/ApiCallRetryTest.php
+++ b/tests/Feature/ApiCallRetryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\ApiCall;
@@ -35,12 +35,12 @@ class ApiCallRetryTest extends TestCase
     {
         $callCount = 0;
         $expectedCalls = 3;
-        
+
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->method('sendRequest')
             ->willReturnCallback(function() use (&$callCount, $expectedCalls) {
                 $callCount++;
-                
+
                 if ($callCount < $expectedCalls) {
                     $response = $this->createMock(ResponseInterface::class);
                     $response->method('getStatusCode')->willReturn(500);
@@ -62,9 +62,9 @@ class ApiCallRetryTest extends TestCase
         ]);
 
         $apiCall = new ApiCall($config);
-        
+
         $result = $apiCall->get('/test', []);
-        
+
         $this->assertEquals(['success' => true], $result);
         $this->assertEquals($expectedCalls, $callCount);
     }
@@ -73,12 +73,12 @@ class ApiCallRetryTest extends TestCase
     {
         $callCount = 0;
         $expectedCalls = 3;
-        
+
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->method('sendRequest')
             ->willReturnCallback(function() use (&$callCount) {
                 $callCount++;
-                
+
                 $response = $this->createMock(ResponseInterface::class);
                 $response->method('getStatusCode')->willReturn(500);
                 throw new HttpException('Server error', $this->createMock(RequestInterface::class), $response);
@@ -95,12 +95,12 @@ class ApiCallRetryTest extends TestCase
         ]);
 
         $apiCall = new ApiCall($config);
-        
+
         $this->expectException(ServerError::class);
         $this->expectExceptionMessage('Server error');
-        
+
         $apiCall->get('/test', []);
-        
+
         $this->assertEquals($expectedCalls, $callCount);
     }
 
@@ -108,12 +108,12 @@ class ApiCallRetryTest extends TestCase
     {
         $callCount = 0;
         $expectedCalls = 1;
-        
+
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->method('sendRequest')
             ->willReturnCallback(function() use (&$callCount, $expectedCalls) {
                 $callCount++;
-                
+
                 if ($callCount < $expectedCalls) {
                     throw new RequestMalformed('Bad request');
                 } else {
@@ -133,12 +133,12 @@ class ApiCallRetryTest extends TestCase
         ]);
 
         $apiCall = new ApiCall($config);
-        
+
         try {
             $apiCall->get('/test', []);
         } catch (ServerError $e) {
         }
-        
+
         $this->assertEquals($expectedCalls, $callCount);
     }
 
@@ -146,12 +146,12 @@ class ApiCallRetryTest extends TestCase
     {
         $callCount = 0;
         $expectedCalls = 3;
-        
+
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->method('sendRequest')
             ->willReturnCallback(function() use (&$callCount, $expectedCalls) {
                 $callCount++;
-                
+
                 if ($callCount < $expectedCalls) {
                     throw new TransferException('Connection error');
                 } else {
@@ -171,9 +171,9 @@ class ApiCallRetryTest extends TestCase
         ]);
 
         $apiCall = new ApiCall($config);
-        
+
         $result = $apiCall->get('/test', []);
-        
+
         $this->assertEquals(['success' => true], $result);
         $this->assertEquals($expectedCalls, $callCount);
     }
@@ -181,12 +181,12 @@ class ApiCallRetryTest extends TestCase
     public function testSkips408TimeoutErrorsAndContinuesRetrying(): void
     {
         $callCount = 0;
-        
+
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->method('sendRequest')
             ->willReturnCallback(function() use (&$callCount) {
                 $callCount++;
-                
+
                 if ($callCount === 1) {
                     $response = $this->createMock(ResponseInterface::class);
                     $response->method('getStatusCode')->willReturn(408);
@@ -212,9 +212,9 @@ class ApiCallRetryTest extends TestCase
         ]);
 
         $apiCall = new ApiCall($config);
-        
+
         $result = $apiCall->get('/test', []);
-        
+
         $this->assertEquals(['success' => true], $result);
         $this->assertEquals(3, $callCount);
     }
@@ -222,12 +222,12 @@ class ApiCallRetryTest extends TestCase
     public function testNodeHealthCheckAfterExceptions(): void
     {
         $callCount = 0;
-        
+
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->method('sendRequest')
             ->willReturnCallback(function() use (&$callCount) {
                 $callCount++;
-                
+
                 $response = $this->createMock(ResponseInterface::class);
                 $response->method('getStatusCode')->willReturn(500);
                 throw new HttpException('Server error', $this->createMock(RequestInterface::class), $response);
@@ -244,32 +244,32 @@ class ApiCallRetryTest extends TestCase
         ]);
 
         $apiCall = new ApiCall($config);
-        
+
         $node1 = $config->getNodes()[0];
         $node2 = $config->getNodes()[1];
-        
+
         $this->assertTrue($node1->isHealthy());
         $this->assertTrue($node2->isHealthy());
-        
+
         try {
             $apiCall->get('/test', []);
         } catch (ServerError $e) {
             $this->assertFalse($node1->isHealthy());
             $this->assertFalse($node2->isHealthy());
         }
-        
+
         $this->assertEquals(3, $callCount);
     }
 
     public function test400ErrorsAreNotRetried(): void
     {
         $callCount = 0;
-        
+
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->method('sendRequest')
             ->willReturnCallback(function() use (&$callCount) {
                 $callCount++;
-                
+
                 $response = $this->createMock(ResponseInterface::class);
                 $response->method('getStatusCode')->willReturn(400);
                 throw new HttpException('Bad Request', $this->createMock(RequestInterface::class), $response);
@@ -286,24 +286,24 @@ class ApiCallRetryTest extends TestCase
         ]);
 
         $apiCall = new ApiCall($config);
-        
+
         $this->expectException(\Typesense\Exceptions\RequestMalformed::class);
         $this->expectExceptionMessage('Bad Request');
-        
+
         $apiCall->get('/test', []);
-        
+
         $this->assertEquals(1, $callCount);
     }
 
     public function test401ErrorsAreNotRetried(): void
     {
         $callCount = 0;
-        
+
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->method('sendRequest')
             ->willReturnCallback(function() use (&$callCount) {
                 $callCount++;
-                
+
                 $response = $this->createMock(ResponseInterface::class);
                 $response->method('getStatusCode')->willReturn(401);
                 throw new HttpException('Unauthorized', $this->createMock(RequestInterface::class), $response);
@@ -320,24 +320,24 @@ class ApiCallRetryTest extends TestCase
         ]);
 
         $apiCall = new ApiCall($config);
-        
+
         $this->expectException(\Typesense\Exceptions\RequestUnauthorized::class);
         $this->expectExceptionMessage('Unauthorized');
-        
+
         $apiCall->get('/test', []);
-        
+
         $this->assertEquals(1, $callCount);
     }
 
     public function test404ErrorsAreNotRetried(): void
     {
         $callCount = 0;
-        
+
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->method('sendRequest')
             ->willReturnCallback(function() use (&$callCount) {
                 $callCount++;
-                
+
                 $response = $this->createMock(ResponseInterface::class);
                 $response->method('getStatusCode')->willReturn(404);
                 throw new HttpException('Not Found', $this->createMock(RequestInterface::class), $response);
@@ -354,24 +354,24 @@ class ApiCallRetryTest extends TestCase
         ]);
 
         $apiCall = new ApiCall($config);
-        
+
         $this->expectException(\Typesense\Exceptions\ObjectNotFound::class);
         $this->expectExceptionMessage('Not Found');
-        
+
         $apiCall->get('/test', []);
-        
+
         $this->assertEquals(1, $callCount);
     }
 
     public function test408ErrorsAreSkippedAndRetryingContinues(): void
     {
         $callCount = 0;
-        
+
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->method('sendRequest')
             ->willReturnCallback(function() use (&$callCount) {
                 $callCount++;
-                
+
                 if ($callCount === 1) {
                     $response = $this->createMock(ResponseInterface::class);
                     $response->method('getStatusCode')->willReturn(408);
@@ -392,9 +392,9 @@ class ApiCallRetryTest extends TestCase
         ]);
 
         $apiCall = new ApiCall($config);
-        
+
         $result = $apiCall->get('/test', []);
-        
+
         $this->assertEquals(['success' => true], $result);
         $this->assertEquals(2, $callCount);
     }
@@ -402,13 +402,13 @@ class ApiCallRetryTest extends TestCase
     public function testDoesNotSleepOnFinalRetryAttempt(): void
     {
         $callCount = 0;
-        $retryIntervalSeconds = 0.1; 
-        
+        $retryIntervalSeconds = 0.1;
+
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->method('sendRequest')
             ->willReturnCallback(function() use (&$callCount) {
                 $callCount++;
-                
+
                 $response = $this->createMock(ResponseInterface::class);
                 $response->method('getStatusCode')->willReturn(500);
                 throw new HttpException('Server error', $this->createMock(RequestInterface::class), $response);
@@ -419,37 +419,37 @@ class ApiCallRetryTest extends TestCase
             'nodes' => [
                 ['host' => 'node1', 'port' => 8108, 'protocol' => 'http']
             ],
-            'num_retries' => 2, 
+            'num_retries' => 2,
             'retry_interval_seconds' => $retryIntervalSeconds,
             'client' => $httpClient
         ]);
 
         $apiCall = new ApiCall($config);
-        
+
         $startTime = microtime(true);
-        
+
         try {
             $apiCall->get('/test', []);
         } catch (ServerError $e) {
         }
-        
+
         $endTime = microtime(true);
         $actualDuration = $endTime - $startTime;
-        
+
         //  2 sleep intervals (between 1st->2nd and 2nd->3rd attempts)
         //  no sleep after the final (3rd) attempt
-        $expectedDuration = $retryIntervalSeconds * 2; 
-        
+        $expectedDuration = $retryIntervalSeconds * 2;
+
         $tolerance = 0.05;
-        
+
         $this->assertEquals(3, $callCount, 'Should make exactly 3 attempts');
         $this->assertLessThan(
-            $expectedDuration + $tolerance, 
+            $expectedDuration + $tolerance,
             $actualDuration,
             "Execution took too long ({$actualDuration}s), suggesting sleep was called on final attempt"
         );
         $this->assertGreaterThan(
-            $expectedDuration - $tolerance, 
+            $expectedDuration - $tolerance,
             $actualDuration,
             "Execution was too fast ({$actualDuration}s), suggesting sleep intervals were skipped"
         );

--- a/tests/Feature/ClientTest.php
+++ b/tests/Feature/ClientTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\Collections;

--- a/tests/Feature/CollectionsTest.php
+++ b/tests/Feature/CollectionsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\Collection;

--- a/tests/Feature/ConfigurationTest.php
+++ b/tests/Feature/ConfigurationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;

--- a/tests/Feature/ConversationModelTest.php
+++ b/tests/Feature/ConversationModelTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\ConversationsTestCase;
 

--- a/tests/Feature/ConversationModelsTest.php
+++ b/tests/Feature/ConversationModelsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\ConversationsTestCase;
 

--- a/tests/Feature/ConversationTest.php
+++ b/tests/Feature/ConversationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\ConversationsTestCase;
 

--- a/tests/Feature/CurationSetItemsTest.php
+++ b/tests/Feature/CurationSetItemsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\Exceptions\ObjectNotFound;
@@ -30,11 +30,11 @@ class CurationSetItemsTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         if (!$this->isV30OrAbove()) {
             $this->markTestSkipped('CurationSetItems is only supported in Typesense v30+');
         }
-        
+
         $this->curationSets = $this->client()->curationSets;
         $this->curationSets->upsert('test-curation-set-items', $this->curationSetData);
     }
@@ -54,7 +54,7 @@ class CurationSetItemsTest extends TestCase
     public function testCanListItemsInACurationSet(): void
     {
         $items = $this->curationSets['test-curation-set-items']->getItems()->retrieve();
-        
+
         $this->assertIsArray($items);
         $this->assertGreaterThan(0, count($items));
         $this->assertEquals('123', $items[0]['includes'][0]['id']);
@@ -75,7 +75,7 @@ class CurationSetItemsTest extends TestCase
                 ],
             ],
         ]);
-        
+
         $this->assertEquals('rule-1', $upserted['id']);
 
         $fetched = $this->curationSets['test-curation-set-items']->getItems()['rule-1']->retrieve();

--- a/tests/Feature/CurationSetsTest.php
+++ b/tests/Feature/CurationSetsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\Exceptions\ObjectNotFound;
@@ -31,11 +31,11 @@ class CurationSetsTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         if (!$this->isV30OrAbove()) {
             $this->markTestSkipped('CurationSets is only supported in Typesense v30+');
         }
-        
+
         $this->curationSets = $this->client()->curationSets;
         $this->upsertResponse = $this->curationSets->upsert('test-curation-set', $this->curationSetData);
     }
@@ -64,7 +64,7 @@ class CurationSetsTest extends TestCase
         $returnData = $this->curationSets->retrieve();
         $this->assertIsArray($returnData);
         $this->assertGreaterThan(0, count($returnData));
-        
+
         $created = null;
         foreach ($returnData as $curationSet) {
             if ($curationSet['name'] === 'test-curation-set') {

--- a/tests/Feature/DebugTest.php
+++ b/tests/Feature/DebugTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 

--- a/tests/Feature/DocumentTest.php
+++ b/tests/Feature/DocumentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\Exceptions\ObjectNotFound;

--- a/tests/Feature/DocumentsTest.php
+++ b/tests/Feature/DocumentsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\Documents;

--- a/tests/Feature/FilterByTest.php
+++ b/tests/Feature/FilterByTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use PHPUnit\Framework\TestCase;
 use Typesense\FilterBy;

--- a/tests/Feature/HealthTest.php
+++ b/tests/Feature/HealthTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 

--- a/tests/Feature/HttpClientsTest.php
+++ b/tests/Feature/HttpClientsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Http\Client\Common\HttpMethodsClient;

--- a/tests/Feature/KeysTest.php
+++ b/tests/Feature/KeysTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\Exceptions\ObjectNotFound;

--- a/tests/Feature/MetricsTest.php
+++ b/tests/Feature/MetricsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 

--- a/tests/Feature/MultiSearchTest.php
+++ b/tests/Feature/MultiSearchTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\Exceptions\RequestMalformed;

--- a/tests/Feature/NLSearchModelsTest.php
+++ b/tests/Feature/NLSearchModelsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\NLSearchModelsTestCase;
 
@@ -23,7 +23,7 @@ class NLSearchModelsTest extends NLSearchModelsTestCase
         $this->assertArrayHasKey('id', $response);
         $this->assertEquals('test-collection-model', $response['id']);
         $this->assertEquals('openai/gpt-3.5-turbo', $response['model_name']);
-        
+
         $this->client()->nlSearchModels['test-collection-model']->delete();
     }
 
@@ -36,12 +36,12 @@ class NLSearchModelsTest extends NLSearchModelsTestCase
             "system_prompt" => "Test model for retrieval.",
             "max_bytes" => 8192
         ];
-        
+
         $this->client()->nlSearchModels->create($testData);
-        
+
         $response = $this->client()->nlSearchModels->retrieve();
         $this->assertIsArray($response);
-        
+
         $foundModel = false;
         foreach ($response as $model) {
             if ($model['id'] === 'retrieve-test-model') {
@@ -126,4 +126,4 @@ class NLSearchModelsTest extends NLSearchModelsTestCase
         $this->assertEquals('test-collection-model', $response['id']);
 
     }
-} 
+}

--- a/tests/Feature/OperationsTest.php
+++ b/tests/Feature/OperationsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 

--- a/tests/Feature/OverridesTest.php
+++ b/tests/Feature/OverridesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\Exceptions\ObjectNotFound;
@@ -15,11 +15,11 @@ class OverridesTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         if ($this->isV30OrAbove()) {
             $this->markTestSkipped('Overrides are deprecated in Typesense v30+, use CurationSets instead');
         }
-        
+
         $this->setUpCollection('books');
 
         $override = [

--- a/tests/Feature/PresetsTest.php
+++ b/tests/Feature/PresetsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\Exceptions\ObjectNotFound;

--- a/tests/Feature/StemmingDictionariesTest.php
+++ b/tests/Feature/StemmingDictionariesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 
@@ -20,7 +20,7 @@ class StemmingDictionariesTest extends TestCase
         parent::setUp();
 
         $this->client()->stemming->dictionaries()->upsert(
-            $this->dictionaryId, 
+            $this->dictionaryId,
             $this->dictionary
         );
     }

--- a/tests/Feature/StopwordsTest.php
+++ b/tests/Feature/StopwordsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\Exceptions\ObjectNotFound;

--- a/tests/Feature/SynonymSetItemsTest.php
+++ b/tests/Feature/SynonymSetItemsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Exception;

--- a/tests/Feature/SynonymSetsTest.php
+++ b/tests/Feature/SynonymSetsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\Exceptions\ObjectNotFound;
@@ -23,11 +23,11 @@ class SynonymSetsTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         if (!$this->isV30OrAbove()) {
             $this->markTestSkipped('SynonymSets is only supported in Typesense v30+');
         }
-        
+
         $this->synonymSets = $this->client()->synonymSets;
         $this->upsertResponse = $this->synonymSets->upsert('test-synonym-set', $this->synonymSetData);
     }
@@ -58,4 +58,4 @@ class SynonymSetsTest extends TestCase
         $this->expectException(ObjectNotFound::class);
         $this->synonymSets['test-synonym-set']->retrieve();
     }
-} 
+}

--- a/tests/Feature/SynonymsTest.php
+++ b/tests/Feature/SynonymsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use Tests\TestCase;
 use Typesense\Exceptions\ObjectNotFound;
@@ -17,11 +17,11 @@ class SynonymsTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         if ($this->isV30OrAbove()) {
             $this->markTestSkipped('Synonyms is deprecated in Typesense v30+, use SynonymSets instead');
         }
-        
+
         $this->setUpCollection('books');
 
         $this->synonyms = $this->client()->collections['books']->synonyms;


### PR DESCRIPTION
## Change Summary

Hi, this PR adds StructArmed to github workflow static analysis for QA.

https://github.com/boundwize/structarmed

StructArmed is a configurable PHP architecture guard, that we can define layers and rules, then keep them enforced. 

For starter, this PR uses the PSR4 preset, and already found violations that fixed and included in this PR.

Since it support php 7.x as well, this only add on github workflow on php 8.4 👍

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
